### PR TITLE
active record connection 조회 관련 문제 개선 & rails 6.1 대응

### DIFF
--- a/lib/standby/active_record/base.rb
+++ b/lib/standby/active_record/base.rb
@@ -35,7 +35,7 @@ module ActiveRecord
       end
 
       def user_db?
-        connection_config[:database] == "hoian_user"
+        connection_db_config.database == "hoian_user"
       end
     end
   end

--- a/lib/standby/connection_holder.rb
+++ b/lib/standby/connection_holder.rb
@@ -2,6 +2,8 @@ module Standby
   class ConnectionHolder < ActiveRecord::Base
     self.abstract_class = true
 
+    CONNECTION_NAME_MAP = {"StandbyStandbyConnectionHolder" => "ActiveRecord::Base", "StandbyStandbyUserdbConnectionHolder" => "MysqlRecord"}
+
     class << self
       # for delayed activation
       def activate(target)
@@ -9,6 +11,10 @@ module Standby
         spec = ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: target.to_s, include_replicas: true)&.configuration_hash
         raise Error.new("Standby target '#{target}' is invalid!") if spec.nil?
         establish_connection spec
+      end
+
+      def name
+        CONNECTION_NAME_MAP[super] || "ActiveRecord::Base"
       end
     end
   end

--- a/lib/standby/connection_holder.rb
+++ b/lib/standby/connection_holder.rb
@@ -5,7 +5,8 @@ module Standby
     class << self
       # for delayed activation
       def activate(target)
-        spec = ActiveRecord::Base.configurations["#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_#{target}"]
+        env_name = ActiveRecord::ConnectionHandling::RAILS_ENV.call
+        spec = ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: target.to_s, include_replicas: true)&.configuration_hash
         raise Error.new("Standby target '#{target}' is invalid!") if spec.nil?
         establish_connection spec
       end

--- a/standby.gemspec
+++ b/standby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'activerecord', '>= 3.0.0'
+  gem.add_runtime_dependency 'activerecord', '>= 6.1.0'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'sqlite3'


### PR DESCRIPTION
- remove deprecated warning
  -  connection_config is deprecated and will be removed from Rails 6.2 (Use connection_db_config instead)
  - [] is deprecated and will be removed from Rails 6.2 (Use configs_for)
- 변경된 ActiveRecord Connection 대응
  - Rails 6.1에서 변경된 DB Configuration 조회 대응
  - ActiveRecord::Base의 role (:writing, :reading) 단위로 커넥션 구분하는 구조가 아니어서 role마다 Standby용 커넥션 객체를 별도로 생성하여 참조하도록 개선